### PR TITLE
examples: Add time_decrypt.c for TPM 2 using IBMTSS 2

### DIFF
--- a/example/tpm_ibmtss2/README.md
+++ b/example/tpm_ibmtss2/README.md
@@ -1,0 +1,197 @@
+Test script for TPM 2
+
+Prerequisites
+-------------
+
+The TPM 2 test script loads the RSA key into the TPM's NULL hierarchy. Please
+make sure that the NULL hierarchy has no password set and no other
+application is using the TPM 2 and sufficient space is available in the TPM for
+loading the RSA key. Since access to TPM devices is typically restricted to the
+root user, the test script (time_decrypt) will need to be run as root.
+
+The TPM 2 test script can for example be run against swtpm using the vtpm
+proxy device:
+
+ > modprobe tpm_vtpm_proxy
+ > swtpm chardev --vtpm-proxy --tpmstate dir=./ --tpm2
+ New TPM device: /dev/tpm1 (major/minor = 253/1)
+
+For the test script to use the proper device, which would be /dev/tpmrm1,
+set the following environment variable:
+
+ TPM_DEVICE=/dev/tpmrm1
+
+
+When using a hardware TPM 2 the following should be used:
+
+ TPM_DEVICE=/dev/tpmrm0
+
+The following packages are needed:
+
+ - openssl-devel / libssl-dev
+ - tss2-devel / libtss2-dev
+ - swtpm-tools
+
+
+OpenSSL *with* implicit rejection
+=================================
+Test harness for OpenSSL *with* implicit rejection a.k.a Marvin workaround.
+
+Usage
+-----
+
+Run `step0.sh`, `step1.sh` as normal. Instead of running `step2.sh` run
+the `step2-marvin.sh` script.
+
+Compile this reproducer:
+```
+gcc -o time_decrypt time_decrypt.c -lcrypto -libmtss
+```
+
+Execute it against one of the `pms_values.bin` files, for either 1024
+(-n 128) or 2048 bit (-n 256):
+```
+TPM_DEVICE=/dev/tpmrm1 TPM_INTERFACE_TYPE=dev ./time_decrypt \
+-i rsa2048_repeat/pms_values.bin -o rsa2048_repeat/raw_times.bin \
+-k rsa2048/pkcs8.pem -n 256
+```
+
+Note:
+If swtpm is **mistakenly** used with a version of OpenSSL that does not
+implement implicit rejection ('older' versions, e.g. OpenSSL 1.1.1), then
+the TPM 2 will return error messages when a decryption failure occurs
+(e.g., detected bad padding) and the output may show the following:
+
+```
+finished  total: 22000 decryption failures: 16000  unexpected msg len: 0
+```
+
+Newer versions of OpenSSL with implicit rejection support will not indicate
+decryption failures but return a message leading to the following output:
+
+```
+finished  total: 22000 decryption failures: 0  unexpected msg len: 0
+```
+
+Convert the captured timing information to a format understandable by
+the analysis script:
+```
+PYTHONPATH=tlsfuzzer marvin-venv/bin/python3 tlsfuzzer/tlsfuzzer/extract.py \
+-l rsa2048_repeat/log.csv --raw-times rsa2048_repeat/raw_times.bin \
+-o rsa2048_repeat/ \
+--binary 8 --endian little --clock-frequency 2712.003
+```
+The `--clock-frequency` is the TSC frequency, as reported by the kernel on
+my machine:
+```
+[    1.506811] tsc: Refined TSC clocksource calibration: 2712.003 MHz
+```
+Specifying it is optional, but then the analysis will interpret clock
+ticks as seconds so interpretation of the results and graphs in terms of
+CPU clock cycles will be more complex.
+
+**Warning:** None of the clock sources used by the `time_decrypt_legacy.c`
+actually run at the same frequency as the CPU frequency! Remember to specify
+`--endian big` when running on s390x!
+
+Finally, run the analysis:
+```
+PYTHONPATH=tlsfuzzer marvin-venv/bin/python3 tlsfuzzer/tlsfuzzer/analysis.py \
+-o rsa2048_repeat/ --verbose
+```
+
+OpenSSL *without* implicit rejection
+====================================
+Test harness for OpenSSL *without* implicit rejection a.k.a Marvin workaround.
+
+Usage
+-----
+
+Run `step0.sh`, `step1.sh` as normal. Instead of running `step2.sh` run
+the `step2-alt.sh` script.
+
+Compile this reproducer:
+```
+gcc -o time_decrypt time_decrypt.c -lcrypto -libmtss
+```
+
+Execute it against one of the `ciphers.bin` files, for example the one
+for 2048 bit key:
+```
+TPM_DEVICE=/dev/tpmrm1 TPM_INTERFACE_TYPE=dev ./time_decrypt \
+-i rsa2048_repeat/ciphers.bin -o rsa2048_repeat/raw_times.bin \
+-k rsa2048/pkcs8.pem -n 256
+```
+
+Note:
+If swtpm is **mistakenly** used with a version of OpenSSL that implements
+implicit rejection ('newer' versions), then the TPM 2 will return
+decrypted messages of unexpected length but not indicate any decrytption
+failures:
+
+```
+finished  total: 1200000 decryption failures: 0  unexpected msg len: 1096285
+```
+
+Older versions of OpenSSL without implicit rejection will indicate
+decryption failures as well as messages of unexpected length:
+
+```
+finished  total: 1200000 decryption failures: 900000  unexpected msg len: 200000
+```
+
+Convert the captured timing information to a format understandable by
+the analysis script:
+```
+PYTHONPATH=tlsfuzzer marvin-venv/bin/python3 tlsfuzzer/tlsfuzzer/extract.py \
+-l rsa2048_repeat/log.csv --raw-times rsa2048_repeat/raw_times.bin \
+-o rsa2048_repeat/ \
+--binary 8 --endian little --clock-frequency 2712.003
+```
+The `--clock-frequency` is the TSC frequency, as reported by the kernel on
+my machine:
+```
+[    1.506811] tsc: Refined TSC clocksource calibration: 2712.003 MHz
+```
+Specifying it is optional, but then the analysis will interpret clock
+ticks as seconds so interpretation of the results and graphs in terms of
+CPU clock cycles will be more complex.
+
+**Warning:** None of the clock sources used by the `time_decrypt.c`
+actually run at the same frequency as the CPU frequency! Remember to specify
+`--endian big` when running on s390x!
+
+Finally, run the analysis:
+```
+PYTHONPATH=tlsfuzzer marvin-venv/bin/python3 tlsfuzzer/tlsfuzzer/analysis.py \
+-o rsa2048_repeat/ --verbose
+```
+
+Interpretation of results
+=========================
+
+Detailed information about produced output is available in
+[tlsfuzzer documentation](https://tlsfuzzer.readthedocs.io/en/latest/timing-analysis.html)
+but what's most important is in the summary:
+```
+Sign test mean p-value: 0.562, median p-value: 0.5909, min p-value: 0.01485
+Friedman test (chisquare approximation) for all samples
+p-value: 0.8505764327569006
+Worst pair: 3(invalid version number (1) in padding), 21(zero byte in third byte of padding)
+Mean of differences: -1.15477e-06s, 95% CI: -2.39868e-06s, -1.775660e-07s (±1.111e-06s)
+Median of differences: -1.15235e-06s, 95% CI: -1.93374e-06s, -2.008180e-07s (±8.665e-07s)
+Trimmed mean (5%) of differences: -1.06137e-06s, 95% CI: -2.07415e-06s, -2.513678e-07s (±9.114e-07s)
+Trimmed mean (25%) of differences: -9.13984e-07s, 95% CI: -1.75922e-06s, -1.177341e-07s (±8.207e-07s)
+Trimmed mean (45%) of differences: -1.02560e-06s, 95% CI: -1.90639e-06s, -1.207689e-07s (±8.928e-07s)
+Trimean of differences: -8.79908e-07s, 95% CI: -1.74172e-06s, -1.827706e-07s (±7.795e-07s)
+Layperson explanation: Large confidence intervals detected, collecting more data necessary. Side channel leakege smaller than 8.207e-07s is possible
+For detailed report see rsa2048_repeat/report.csv
+Analysis return value: 0
+```
+
+The Friedman test p-value specifies how confident is the test in presence of
+side channel (the smaller the p-value the more confident it is, i.e. a
+p-value of 1e-6 means 1 in a million chance that there isn't a side-channel).
+The other important information is the 95% Confidence Intervals reported,
+it specifies how sensitive the script is (in this case it's unlikely that
+it would be able to detect a side channel smaller than 8.665e-07s or 866ns).

--- a/example/tpm_ibmtss2/time_decrypt.c
+++ b/example/tpm_ibmtss2/time_decrypt.c
@@ -1,0 +1,425 @@
+#include <memory.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/rsa.h>
+#include <openssl/pem.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+# include <openssl/core_names.h>
+#endif
+
+#define TPM_POSIX
+#include <ibmtss/tss.h>
+#include <ibmtss/tssutils.h>
+#include <ibmtss/tsscrypto.h>
+#include <ibmtss/tssresponsecode.h>
+#include <ibmtss/tssmarshal.h>
+#include <ibmtss/Unmarshal_fp.h>
+
+void help(char *name) {
+    printf("Usage: %s -i file -o file -k file -n num [-h]\n", name);
+    printf("\n");
+    printf(" -i file    File with concatenated ciphertexts to decrypt\n");
+    printf(" -o file    File where to write the time to decrypt the ciphertext\n");
+    printf(" -k file    File with the RSA private key in PEM format\n");
+    printf(" -n num     Length of individual ciphertexts in bytes\n");
+    printf(" -v         Turn on TSS log/debug messages\n");
+    printf(" -V         Turn decryption error messages\n");
+    printf(" -h         This message\n");
+}
+
+/* Get an architecture specific most precise clock source with the lowest
+ * overhead. Should be executed at the start of the measurement period
+ * (because of barriers against speculative execution
+ */
+uint64_t get_time_before() {
+    uint64_t time_before = 0;
+#if defined( __s390x__ )
+    /* The 64 bit TOD (time-of-day) value is running at 4096.000MHz, but
+     * on some machines not all low bits are updated (the effective frequency
+     * remains though)
+     */
+
+    /* use STCKE as it has lower overhead,
+     * see http://publibz.boulder.ibm.com/epubs/pdf/dz9zr007.pdf
+     */
+    //asm volatile (
+    //    "stck    %0": "=Q" (time_before) :: "memory", "cc");
+
+    uint8_t clk[16];
+    asm volatile (
+          "stcke %0" : "=Q" (clk) :: "memory", "cc");
+    /* since s390x is big-endian we can just do a byte-by-byte copy,
+     * First byte is the epoch number (143 year cycle) while the following
+     * 8 bytes are the same as returned by STCK */
+    time_before = *(uint64_t *)(clk + 1);
+#elif defined( __PPC64__ )
+    asm volatile (
+        "mftb    %0": "=r" (time_before) :: "memory", "cc");
+#elif defined( __aarch64__ )
+    asm volatile (
+        "mrs %0, cntvct_el0": "=r" (time_before) :: "memory", "cc");
+#elif defined( __x86_64__ )
+    uint32_t time_before_high = 0, time_before_low = 0;
+    asm volatile (
+        "CPUID\n\t"
+        "RDTSC\n\t"
+        "mov %%edx, %0\n\t"
+        "mov %%eax, %1\n\t" : "=r" (time_before_high),
+        "=r" (time_before_low)::
+        "%rax", "%rbx", "%rcx", "%rdx");
+    time_before = (uint64_t)time_before_high<<32 | time_before_low;
+#else
+#error Unsupported architecture
+#endif /* ifdef __s390x__ */
+    return time_before;
+}
+
+/* Get an architecture specific most precise clock source with the lowest
+ * overhead. Should be executed at the end of the measurement period
+ * (because of barriers against speculative execution
+ */
+uint64_t get_time_after() {
+    uint64_t time_after = 0;
+#if defined( __s390x__ )
+    /* The 64 bit TOD (time-of-day) value is running at 4096.000MHz, but
+     * on some machines not all low bits are updated (the effective frequency
+     * remains though)
+     */
+
+    /* use STCKE as it has lower overhead,
+     * see http://publibz.boulder.ibm.com/epubs/pdf/dz9zr007.pdf
+     */
+    //asm volatile (
+    //    "stck    %0": "=Q" (time_before) :: "memory", "cc");
+
+    uint8_t clk[16];
+    asm volatile (
+          "stcke %0" : "=Q" (clk) :: "memory", "cc");
+    /* since s390x is big-endian we can just do a byte-by-byte copy,
+     * First byte is the epoch number (143 year cycle) while the following
+     * 8 bytes are the same as returned by STCK */
+    time_after = *(uint64_t *)(clk + 1);
+#elif defined( __PPC64__ )
+    /* Note: mftb can be used with a single instruction on ppc64, for ppc32
+     * it's necessary to read upper and lower 32bits of the values in two
+     * separate calls and verify that we didn't do that during low value
+     * overflow
+     */
+    asm volatile (
+        "mftb    %0": "=r" (time_after) :: "memory", "cc");
+#elif defined( __aarch64__ )
+    asm volatile (
+        "mrs %0, cntvct_el0": "=r" (time_after) :: "memory", "cc");
+#elif defined( __x86_64__ )
+    uint32_t time_after_high = 0, time_after_low = 0;
+    asm volatile (
+        "RDTSCP\n\t"
+        "mov %%edx, %0\n\t"
+        "mov %%eax, %1\n\t"
+        "CPUID\n\t": "=r" (time_after_high),
+        "=r" (time_after_low)::
+        "%rax", "%rbx", "%rcx", "%rdx");
+    time_after = (uint64_t)time_after_high<<32 | time_after_low;
+#else
+#error Unsupported architecture
+#endif /* ifdef __s390x__ */
+    return time_after;
+}
+
+TPM_RC RsaPemToTPM(EVP_PKEY            *pkey,
+                   TPM2B_SENSITIVE     *objSensitive,
+                   TPM2B_PUBLIC        *objPublic,
+                   TPMI_ALG_SIG_SCHEME  scheme,
+                   TPMI_ALG_HASH        nameAlg)
+{
+    TPMT_SENSITIVE *tSensitive = &objSensitive->t.sensitiveArea;
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    BIGNUM *p = NULL;
+    BIGNUM *n = NULL;
+#else
+    const BIGNUM *p = NULL;
+    const BIGNUM *n = NULL;
+    const RSA *rsa;
+#endif
+    TPM_RC rc = -1;
+
+    objSensitive->t.size = sizeof(*tSensitive);
+
+    tSensitive->sensitiveType = TPM_ALG_RSA;
+    tSensitive->authValue.b.size = 0;
+    tSensitive->seedValue.b.size = 0;
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_FACTOR1, &p)) {
+        fprintf(stderr, "EVP_PKEY_get_bn_param failed for factor 1\n");
+        return -1;
+    }
+#else
+    rsa = EVP_PKEY_get0_RSA(pkey);
+    p = RSA_get0_p(rsa);
+#endif
+    if (BN_num_bytes(p) > sizeof(tSensitive->sensitive.rsa.t.buffer)) {
+        fprintf(stderr, "Private exponent is too large: %d > %zu\n",
+                BN_num_bytes(p), sizeof(tSensitive->sensitive.rsa.t.buffer));
+        return -1;
+    }
+    tSensitive->sensitive.rsa.t.size = BN_num_bytes(p);
+    BN_bn2bin(p, tSensitive->sensitive.rsa.t.buffer);
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    if (!EVP_PKEY_get_bn_param(pkey, OSSL_PKEY_PARAM_RSA_N, &n)) {
+        fprintf(stderr, "EVP_PKEY_get_bn_param failed for modulus\n");
+        goto error;
+    }
+#else
+    n = RSA_get0_n(rsa);
+#endif
+    if (BN_num_bytes(n) > sizeof(objPublic->publicArea.unique.rsa.t.buffer)) {
+        fprintf(stderr, "Modulus is too large: %d > %zu\n",
+                BN_num_bytes(n), sizeof(objPublic->publicArea.unique.rsa.t.buffer));
+        goto error;
+    }
+
+    objPublic->publicArea.type = TPM_ALG_RSA;
+    objPublic->publicArea.nameAlg = nameAlg;
+    objPublic->publicArea.objectAttributes.val = TPMA_OBJECT_NODA |
+                                                 TPMA_OBJECT_USERWITHAUTH |
+                                                 TPMA_OBJECT_DECRYPT;
+    objPublic->publicArea.parameters.rsaDetail.symmetric.algorithm = TPM_ALG_NULL;
+    objPublic->publicArea.authPolicy.t.size = 0;
+    objPublic->publicArea.parameters.rsaDetail.scheme.scheme = TPM_ALG_RSAES;
+    objPublic->publicArea.parameters.rsaDetail.keyBits = BN_num_bytes(n) * 8;
+    objPublic->publicArea.parameters.rsaDetail.exponent = 0;
+
+    objPublic->publicArea.unique.rsa.t.size = BN_num_bytes(n);
+    BN_bn2bin(n, objPublic->publicArea.unique.rsa.t.buffer);
+
+    rc = 0;
+
+error:
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    BN_free(p);
+    BN_free(n);
+#endif
+
+    return rc;
+}
+
+int main(int argc, char *argv[]) {
+    int result = 1, r_ret;
+    EVP_PKEY_CTX *ctx = NULL;
+    EVP_PKEY *pkey = NULL;
+    size_t ciphertext_len = 0;
+    FILE *fp;
+    char *key_file_name = NULL, *in_file_name = NULL, *out_file_name = NULL;
+    int in_fd = -1, out_fd = -1;
+    unsigned char *ciphertext = NULL;
+    unsigned char *plaintext = NULL;
+    int opt;
+    uint64_t time_before, time_after, time_diff;
+    TPM_RC rc;
+    LoadExternal_In le_in;
+    LoadExternal_Out le_out;
+    RSA_Decrypt_In rd_in;
+    RSA_Decrypt_Out rd_out;
+    TSS_CONTEXT *tssContext = NULL;
+    int verbose = 0;
+
+    while ((opt = getopt(argc, argv, "i:o:k:n:vVh")) != -1 ) {
+        switch (opt) {
+            case 'i':
+                in_file_name = optarg;
+                break;
+            case 'o':
+                out_file_name = optarg;
+                break;
+            case 'k':
+                key_file_name = optarg;
+                break;
+            case 'n':
+                sscanf(optarg, "%zi", &ciphertext_len);
+                break;
+            case 'v':
+                TSS_SetProperty(NULL, TPM_TRACE_LEVEL, "2");
+                break;
+            case 'V':
+                verbose = 1;
+                break;
+            case 'h':
+                help(argv[0]);
+                exit(0);
+                break;
+            default:
+                fprintf(stderr, "Unknown option: %c\n", opt);
+                help(argv[0]);
+                exit(1);
+                break;
+        }
+    }
+
+    if (!in_file_name || !out_file_name || !key_file_name || !ciphertext_len) {
+        fprintf(stderr, "Missing parameters!\n");
+        help(argv[0]);
+        exit(1);
+    }
+
+    in_fd = open(in_file_name, O_RDONLY);
+    if (in_fd == -1) {
+        fprintf(stderr, "can't open input file %s\n", in_file_name);
+        goto err;
+    }
+
+    out_fd = open(out_file_name, O_WRONLY|O_TRUNC|O_CREAT, 0666);
+    if (out_fd == -1) {
+        fprintf(stderr, "can't open output file %s\n", out_file_name);
+        goto err;
+    }
+
+    fprintf(stderr, "malloc(plaintext)\n");
+    plaintext = malloc(ciphertext_len);
+    if (!plaintext)
+        goto err;
+
+    fprintf(stderr, "malloc(ciphertext)\n");
+    ciphertext = malloc(ciphertext_len);
+    if (!ciphertext)
+        goto err;
+
+    fprintf(stderr, "fopen()\n");
+    fp = fopen(key_file_name, "r");
+    if (!fp) {
+        fprintf(stderr, "Can't open key file %s\n", key_file_name);
+        goto err;
+    }
+
+    fprintf(stderr, "PEM_read_PrivateKey()\n");
+    if ((pkey = PEM_read_PrivateKey(fp, NULL, NULL, NULL)) == NULL)
+        goto err;
+
+    fprintf(stderr, "fclose()\n");
+    if (fclose(fp) != 0)
+        goto err;
+    fp = NULL;
+
+    fprintf(stderr, "RsaPemToTPM()\n");
+    memset(&le_in, 0, sizeof(le_in));
+    if (RsaPemToTPM(pkey, &le_in.inPrivate, &le_in.inPublic,
+                    TPM_ALG_NULL, TPM_ALG_SHA256) < 0) {
+        fprintf(stderr, "Could not convert key to public\n");
+        goto err;
+    }
+    le_in.hierarchy = TPM_RH_NULL;
+
+    if (ciphertext_len > le_in.inPublic.publicArea.unique.rsa.t.size) {
+        fprintf(stderr, "The -n parameter is larger then the size of modulus: %zu > %d\n",
+                ciphertext_len, le_in.inPublic.publicArea.unique.rsa.t.size);
+        goto err;
+    }
+
+    if ((rc = TSS_Create(&tssContext)) != 0) {
+        fprintf(stderr, "Could not create TSS context: 0x%x\n", rc);
+        goto err;
+    }
+
+    if ((rc = TSS_Execute(tssContext,
+                          (RESPONSE_PARAMETERS *)&le_out,
+                          (COMMAND_PARAMETERS *)&le_in,
+                          NULL,
+                          TPM_CC_LoadExternal,
+                          TPM_RH_NULL, NULL, 0,
+                          TPM_RH_NULL, NULL, 0,
+                          TPM_RH_NULL, NULL, 0,
+                          TPM_RH_NULL, NULL, 0)) != 0) {
+        fprintf(stderr, "Could not execute LoadExternal command: 0x%x\n", rc);
+        goto err;
+    }
+
+    fprintf(stderr, "Decrypting ciphertexts using TPM 2 ...\n");
+
+    int c = 0, dec_fail = 0, msg_fail = 0;
+
+    while ((r_ret = read(in_fd, ciphertext, ciphertext_len)) > 0) {
+        if (r_ret != ciphertext_len) {
+            fprintf(stderr, "read less data than expected (truncated file?)\n");
+            goto err;
+        }
+        c++;
+
+        memset(&rd_in, 0, sizeof(rd_in));
+        rd_in.keyHandle = le_out.objectHandle;
+        rd_in.cipherText.t.size = ciphertext_len;
+        memcpy(rd_in.cipherText.t.buffer, ciphertext, ciphertext_len);
+        rd_in.inScheme.scheme = TPM_ALG_RSAES;
+        rd_in.label.t.size = 0;
+
+        time_before = get_time_before();
+
+        r_ret = TSS_Execute(tssContext,
+                            (RESPONSE_PARAMETERS *)&rd_out,
+                            (COMMAND_PARAMETERS *)&rd_in,
+                            NULL,
+                            TPM_CC_RSA_Decrypt,
+                            TPM_RS_PW, "", 0,
+                            TPM_RH_NULL, NULL, 0,
+                            TPM_RH_NULL, NULL, 0,
+                            TPM_RH_NULL, NULL, 0);
+
+        time_after = get_time_after();
+
+        if (r_ret != 0) {
+            if (verbose) {
+                fprintf(stderr, "Decryption failure: 0x%x\n", r_ret);
+                fprintf(stderr, "%x\n", ciphertext[0]);
+            }
+            dec_fail++;
+        } else if (rd_out.message.t.size != 48) {
+            /* this should not happen */
+            if (verbose)
+                fprintf(stderr, "Unexpected plaintext size: %d\n",
+                        rd_out.message.t.size);
+            msg_fail++;
+        }
+
+        time_diff = time_after - time_before;
+
+        r_ret = write(out_fd, &time_diff, sizeof(time_diff));
+        if (r_ret <= 0) {
+            fprintf(stderr, "Write error\n");
+            goto err;
+        }
+    }
+
+    result = 0;
+    fprintf(stderr,
+            "finished  total: %d decryption failures: %d  unexpected msg len: %d\n",
+            c, dec_fail, msg_fail);
+    goto out;
+
+    err:
+    fprintf(stderr, "failed!\n");
+    ERR_print_errors_fp(stderr);
+    result = 1;
+
+    out:
+    if (tssContext)
+        TSS_Delete(tssContext);
+    if (ciphertext)
+        free(ciphertext);
+    if (plaintext)
+        free(plaintext);
+    if (ctx)
+        EVP_PKEY_CTX_free(ctx);
+    if (pkey)
+        EVP_PKEY_free(pkey);
+    if (in_fd >= 0)
+        close(in_fd);
+    if (out_fd >= 0)
+        close(out_fd);
+    return result;
+}


### PR DESCRIPTION
Add a script for taking time measurements of the decryption operation of a TPM 2. It uses the TPM 2's NULL hierarchy to load the RSA key into and then decrypts all messages using this key. It also counts the number of decryption failures and returned messages of unexpected size and reports them at the end.

Use the following command to compile:

 gcc time_decrypt.c -o time_decrypt -lcrypto -libmtss