### PR TITLE
Add .NET example.

### DIFF
--- a/example/dotnet-cryptography/Program.cs
+++ b/example/dotnet-cryptography/Program.cs
@@ -1,0 +1,54 @@
+﻿using System.CommandLine;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+var inputOption = new Option<FileInfo>(name: "-i", description: "File with the ciphertexts to decrypt.")  { IsRequired = true };
+var outputOption = new Option<FileInfo>(name: "-o", description: "File to write the timing data to.")  { IsRequired = true };
+var keyOption = new Option<FileInfo>(name: "-k", description: "The private key to use for decryption.")  { IsRequired = true };
+var sizeOption = new Option<int>(name: "-n", description: "Size of individual ciphertexts for decryption.")  { IsRequired = true };
+
+var rootCommand = new RootCommand();
+rootCommand.AddOption(inputOption);
+rootCommand.AddOption(outputOption);
+rootCommand.AddOption(keyOption);
+rootCommand.AddOption(sizeOption);
+
+rootCommand.SetHandler((FileInfo inputFile, FileInfo outputFile, FileInfo keyFile, int size) =>
+{
+    using FileStream input = inputFile.OpenRead();
+
+    using RSA rsa = RSA.Create();
+    var paddingMode = RSAEncryptionPadding.Pkcs1;
+    rsa.ImportFromPem(File.ReadAllText(keyFile.FullName));
+
+    using StreamWriter output = new StreamWriter(outputFile.FullName);
+    output.WriteLine("raw times");
+
+    byte[] data = new byte[size];
+    while (true)
+    {
+        int n = input.Read(data);
+        if (n == 0)
+        {
+            break;
+        }
+
+        if (n != size)
+        {
+            throw new InvalidOperationException($"The input file '{inputFile.FullName}' length is not a multiple of '{size}'.");
+        }
+
+        long startTime = Stopwatch.GetTimestamp();
+        try
+        {
+            rsa.Decrypt(data, paddingMode);
+        }
+        catch
+        { }
+        TimeSpan elapedTime = Stopwatch.GetElapsedTime(startTime);
+
+        output.WriteLine((long)elapedTime.TotalNanoseconds);
+    }
+}, inputOption, outputOption, keyOption, sizeOption);
+
+return rootCommand.Invoke(args);

--- a/example/dotnet-cryptography/README.md
+++ b/example/dotnet-cryptography/README.md
@@ -1,0 +1,60 @@
+Test harness for .NET RSA class *without* implicit
+rejection a.k.a Marvin workaround, implemented by the underlying OpenSSL.
+
+Usage
+=====
+
+Run `step0.sh`, `step1.sh` as normal. Instead of running `step2.sh` run
+the `step2-alt.sh` script.
+
+To build and run the reproducer, the .NET 8 SDK is required.
+It can be installed using the `dotnet-sdk-8.0` distro package.
+
+Execute reproducer against one of the `ciphers.bin` files, for example the one
+for 2048 bit key:
+```
+dotnet run -c Release -- -i rsa2048_repeat/ciphers.bin \
+-o rsa2048_repeat/raw_times.csv -k rsa2048/pkcs8.pem -n 256
+```
+
+Convert the captured timing information to a format understandable by
+the analysis script:
+```
+PYTHONPATH=tlsfuzzer marvin-venv/bin/python3 tlsfuzzer/tlsfuzzer/extract.py \
+-l rsa2048_repeat/log.csv --raw-times rsa2048_repeat/raw_times.csv \
+-o rsa2048_repeat/ \
+--clock-frequency 1000
+```
+Since we're using a nanosecond resolution clock in the python script,
+we specify the clock frequency as 1000 MHz.
+
+Finally, run the analysis:
+```
+PYTHONPATH=tlsfuzzer marvin-venv/bin/python3 tlsfuzzer/tlsfuzzer/analysis.py \
+-o rsa2048_repeat/ --verbose
+```
+
+Detailed information about produced output is available in
+[tlsfuzzer documentation](https://tlsfuzzer.readthedocs.io/en/latest/timing-analysis.html)
+but what's most important is in the summary:
+```
+Sign test mean p-value: 0.5538, median p-value: 0.562, min p-value: 0.06575
+Friedman test (chisquare approximation) for all samples
+p-value: 0.9617988327160067
+Worst pair: 8(valid_246), 11(zero_byte_in_padding_48_4)
+Mean of differences: -2.59050e-07s, 95% CI: -4.24877e-06s, 3.403219e-06s (±3.826e-06s)
+Median of differences: -4.29572e-08s, 95% CI: -9.08922e-08s, 5.531000e-09s (±4.821e-08s)
+Trimmed mean (5%) of differences: -3.89065e-07s, 95% CI: -1.18398e-06s, 3.069665e-07s (±7.455e-07s)
+Trimmed mean (25%) of differences: -6.51617e-08s, 95% CI: -1.41947e-07s, 1.304047e-08s (±7.749e-08s)
+Trimmed mean (45%) of differences: -4.19826e-08s, 95% CI: -9.36116e-08s, 8.553458e-09s (±5.108e-08s)
+Trimean of differences: -4.15053e-08s, 95% CI: -9.20906e-08s, 9.241294e-09s (±5.067e-08s)
+For detailed report see rsa2048_repeat/report.csv
+Analysis return value: 0
+```
+
+The Friedman test p-value specifies how confident is the test in presence of
+side channel (the smaller the p-value the more confidant it is, e.g. a
+p-value of 1e-6 means 1 in a million chance that there isn't a side-channel).
+The other important information are the 95% Confidence Intervals reported,
+they specify how sensitive is the script (in this case it's unlikely that
+it would be able to detect a side channel smaller than 4.821e-08s or 48ns).

--- a/example/dotnet-cryptography/dotnet-cryptography.csproj
+++ b/example/dotnet-cryptography/dotnet-cryptography.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>dotnet_cryptography</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="system.commandline" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This translates the pyca-cryptography example to its .NET equivalent.

cc @tomato42